### PR TITLE
feat: Change el flag type to string

### DIFF
--- a/docker-compose.besu-nimbus2.yml
+++ b/docker-compose.besu-nimbus2.yml
@@ -66,7 +66,7 @@ services:
       --bootstrap-file=/configs/bootnodes.txt
       --genesis-state=/configs/genesis.ssz
       --jwt-secret=/configs/jwt.hex
-      --el=['http://127.0.0.1:8551']
+      --el='http://127.0.0.1:8551'
       --nat=extip:$EXTERNAL_IP
       --rest
       --rest-address='127.0.0.1'

--- a/docker-compose.erigon-nimbus2.yml
+++ b/docker-compose.erigon-nimbus2.yml
@@ -80,7 +80,7 @@ services:
       --bootstrap-file=/configs/bootnodes.txt
       --genesis-state=/configs/genesis.ssz
       --jwt-secret=/configs/jwt.hex
-      --el=['http://127.0.0.1:8551']
+      --el='http://127.0.0.1:8551'
       --nat=extip:$EXTERNAL_IP
       --rest
       --rest-address='127.0.0.1'

--- a/docker-compose.geth-nimbus2.yml
+++ b/docker-compose.geth-nimbus2.yml
@@ -87,7 +87,7 @@ services:
       --bootstrap-file=/configs/bootnodes.txt
       --genesis-state=/configs/genesis.ssz
       --jwt-secret=/configs/jwt.hex
-      --el=['http://127.0.0.1:8551']
+      --el=http://127.0.0.1:8551
       --nat=extip:$EXTERNAL_IP
       --rest
       --rest-address='127.0.0.1'

--- a/docker-compose.nethermind-nimbus2.yml
+++ b/docker-compose.nethermind-nimbus2.yml
@@ -65,7 +65,7 @@ services:
       --bootstrap-file=/configs/bootnodes.txt
       --genesis-state=/configs/genesis.ssz
       --jwt-secret=/configs/jwt.hex
-      --el=['http://127.0.0.1:8551']
+      --el='http://127.0.0.1:8551'
       --nat=extip:$EXTERNAL_IP
       --rest
       --rest-address='127.0.0.1'


### PR DESCRIPTION
This PR fixes a bug where nimbus was unable to correctly connect to EL, due to incorrectly (in docker) set `--el` flag.